### PR TITLE
fixes PS1 error

### DIFF
--- a/_episodes/02-filedir.md
+++ b/_episodes/02-filedir.md
@@ -44,14 +44,14 @@ abramos una terminal:
 > ## La magia de preparación
 >
 > Si escribes el comando:
-> `PS1 = '$'`
+> `PS1='$ '`
 > En tu terminal, seguido de presionar la tecla 'enter',
 > tu ventana debe verse como nuestro ejemplo en esta lección.
 > Esto no es necesario para continuar así que lo dejamos a tu criterio.
 {: .callout}
 
 ~~~
-$
+$ 
 ~~~
 {: .bash}
 


### PR DESCRIPTION
The current formatting with spaces around the equal sign (PS1 = '$') throws an error. I removed the spaces around the equal sign. I also added a space after the $ to provide a gap between the prompt and the user entered command.

